### PR TITLE
Fix ReadToEnd array saving data to the wrong index

### DIFF
--- a/Aero/Aero.Gen/Genv2.cs
+++ b/Aero/Aero.Gen/Genv2.cs
@@ -512,8 +512,6 @@ namespace Aero.Gen
             if (node?.Parent is AeroArrayNode arrayNode                       &&
                 arrayNode.Mode               == AeroArrayNode.Modes.ReadToEnd &&
                 arrayNode.Nodes.Last().Index == node.Index) {
-                var idxName = $"idx{arrayNode.Depth}";
-                AddLine($"{idxName}++;");
                 AddLine(
                     $"{arrayNode.Nodes.First().Name}Count++;"); // TODO: Move this to after the loop so its only one increment, awkward atm to know when we have just done a loops closing bracket
             }
@@ -568,6 +566,11 @@ namespace Aero.Gen
 
         private void CreateUnpackerPreNode(AeroNode node)
         {
+            if (node?.Parent is AeroArrayNode arrayNode2 && arrayNode2.Nodes.First().Index == node?.Index && arrayNode2.Mode == AeroArrayNode.Modes.ReadToEnd) {
+                var idxName = $"idx{arrayNode2.Depth}";
+                AddLine($"{idxName}++;");
+            }
+
             if (node is AeroBlockNode) {
                 LogDiagRead(node, iaAeroBlockDefine: true);
             }
@@ -895,7 +898,7 @@ namespace Aero.Gen
                 case AeroArrayNode.Modes.ReadToEnd:
                     if (createArray) {
                         AddLine($"{firstSubNode.GetFullName(true)} = new {firstSubNode.TypeStr}[{-arrayNode.Length}];");
-                        AddLine($"var {idxName} = 0;");
+                        AddLine($"var {idxName} = -1;");
                         LogDiagRead(arrayNode, isArrayDefine: true);
                         AddLine("while (offset < data.Length)");
                     }


### PR DESCRIPTION
Currently, when using ReadToEnd array mode with a block, Aero generates code like this:

```csharp
// Array ReadToEnd
DataCount = 0;
Data = new AeroMessages.GSS.V66.Character.Event.CombatLogRow[1];
var idx1 = 0;
ReadLogs.Add(new AeroReadLog($"", $"Data", true, typeof(AeroMessages.GSS.V66.Character.Event.CombatLogRow), offset));
while (offset < data.Length)
{
    ReadLogs.Add(new AeroReadLog($"Data", $"{idx1}", false, typeof(AeroMessages.GSS.V66.Character.Event.CombatLogRow), offset));
    // Block Data, Type: AeroMessages.GSS.V66.Character.Event.CombatLogRow
    idx1++;
    DataCount++;
    {
        // Field: Unk1, Type: byte, enum type: 
        Data[idx1].Unk1 = data[offset];
        offset += 1;
```

Because `idx1` is incremented before the actual parsing of the block data, Aero ends up saving the data on the wrong index of the array.
I couldn't find any easy ways to move this to the end of the loop, so instead I went for changing the starting index to -1, so that we would increment and be at index 0 early. However, the ReadLog of the block was happening first, so I moved the increment to the top of the loop by using prenode.

Now, Aero will instead generate the code like this:

```csharp
// Array ReadToEnd
DataCount = 0;
Data = new AeroMessages.GSS.V66.Character.Event.CombatLogRow[24];
var idx1 = -1;
ReadLogs.Add(new AeroReadLog($"", $"Data", true, typeof(AeroMessages.GSS.V66.Character.Event.CombatLogRow), offset));
while (offset < data.Length)
{
    idx1++;
    ReadLogs.Add(new AeroReadLog($"Data", $"{idx1}", false, typeof(AeroMessages.GSS.V66.Character.Event.CombatLogRow), offset));
    // Block Data, Type: AeroMessages.GSS.V66.Character.Event.CombatLogRow
    DataCount++;
    {
        // Field: Unk1, Type: byte, enum type: 
        Data[idx1].Unk1 = data[offset];
        offset += 1;
```

