### PR TITLE
Support encounter views

### DIFF
--- a/Aero/Aero.Gen/AGUtils.cs
+++ b/Aero/Aero.Gen/AGUtils.cs
@@ -274,6 +274,13 @@ namespace Aero.Gen
             return false;
         }
 
+        public static bool IsEncounterClass(ClassDeclarationSyntax cd, SemanticModel sm)
+        {
+            var aeroAttr = NodeWithName<AttributeSyntax>(cd, AeroEncounterAttribute.Name);
+
+            return aeroAttr != null;
+        }
+
         /*{
             return NodeWithName<AttributeSyntax>(fd, name);
                 fd.DescendantNodes().OfType<AttributeSyntax>()

--- a/Aero/Aero.Gen/AeroSyntaxReceiver.cs
+++ b/Aero/Aero.Gen/AeroSyntaxReceiver.cs
@@ -13,9 +13,10 @@ namespace Aero.Gen
         public GeneratorExecutionContext    Context;
         public List<ClassDeclarationSyntax> ClassesToAugment { get; private set; } = new();
         
-        public List<ClassDeclarationSyntax>                AeroClasses     { get; private set; } = new();
-        public Dictionary<string, StructDeclarationSyntax> AeroBlockLookup { get; private set; } = new();
-        public Dictionary<string, AeroMessageIdAttribute>  AeroMessageIds  { get; private set; } = new();
+        public List<ClassDeclarationSyntax>                AeroClasses          { get; private set; } = new();
+        public List<ClassDeclarationSyntax>                AeroEncounterClasses { get; private set; } = new();
+        public Dictionary<string, StructDeclarationSyntax> AeroBlockLookup      { get; private set; } = new();
+        public Dictionary<string, AeroMessageIdAttribute>  AeroMessageIds       { get; private set; } = new();
 
         public static bool HasAttribute(ClassDeclarationSyntax cds, string attributeName) => cds.AttributeLists.Any(x => x.Attributes.Any(y => (y.Name is IdentifierNameSyntax ins && ins.Identifier.Text == attributeName) ||
                                                                                                                                                (y.Name is QualifiedNameSyntax qns && qns.ToString() == attributeName)));
@@ -43,6 +44,11 @@ namespace Aero.Gen
                             AeroMessageIds.Add(asString, aeroMsgInfo);
                         }
                     }
+                }
+
+                if (HasAttribute(cds, "AeroEncounter"))
+                {
+                    AeroEncounterClasses.Add(cds);
                 }
             }
             

--- a/Aero/Aero.Gen/Attributes/AeroEncounterAttribute.cs
+++ b/Aero/Aero.Gen/Attributes/AeroEncounterAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Aero.Gen.Attributes
+{    
+    [AttributeUsage(AttributeTargets.Class)]
+    public class AeroEncounterAttribute : Attribute
+    {
+        public static string Name = "AeroEncounter";
+
+        public string EncounterType;
+
+        public AeroEncounterAttribute(string encounterType)
+        {
+            EncounterType = encounterType;
+        }
+    }
+}

--- a/Aero/Aero.Gen/GenV2.Encounters.cs
+++ b/Aero/Aero.Gen/GenV2.Encounters.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Text;
+using Aero.Gen.Attributes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Aero.Gen
+{
+    public partial class Genv2
+    {
+        private void GenerateEncounterFunctions(ClassDeclarationSyntax cd, SemanticModel sm)
+        {
+            GenerateEncounterHeader(cd);
+
+            GenerateViewUpdateUnpacker(cd, sm);
+            GenerateViewUpdatePacker(cd, sm);
+            GenerateClearViewChanges(cd);
+            GenerateGetPackedChangesSize(cd, sm);
+        }
+
+        private void GenerateEncounterHeader(ClassDeclarationSyntax cd)
+        {
+            var encounterAttr = AgUtils.NodeWithName<AttributeSyntax>(cd, AeroEncounterAttribute.Name);
+
+            var encounterType = encounterAttr.ArgumentList.Arguments[0].Expression.ToString().Trim('"');
+
+            string NameToHex(string name)
+            {
+                var bytes = Encoding.UTF8.GetBytes(name + '\0');
+
+                var hex = new StringBuilder();
+
+                foreach (var b in bytes)
+                {
+                    hex.AppendFormat("0x{0:X2}, ", b);
+                }
+
+                return hex.ToString().Trim();
+            }
+
+            var rootNode = AeroSourceGraphGen.BuildTree(SyntaxReceiver, cd);
+            byte fieldIdx = 0;
+
+            AddLine("public static readonly byte[] Header = {");
+            Indent();
+
+            AddLine($"{NameToHex(encounterType)} // {encounterType}");
+
+            AeroSourceGraphGen.WalkTree(rootNode, node =>
+            {
+                if (node.Depth != 0)
+                {
+                    return;
+                }
+
+                var name = node.Name;
+                byte count = 1;
+
+                if (node is AeroArrayNode arr)
+                {
+                    if (arr.Mode != AeroArrayNode.Modes.Fixed)
+                    {
+                        Context.ReportDiagnostic(
+                            Diagnostic.Create(AeroGenerator.InvalidArrayModeInEncounterView, cd.GetLocation(), name, arr.Mode)
+                        );
+                    }
+
+                    name = arr.Nodes[0].Name;
+                    count = (byte)arr.Length;
+                }
+
+                var typeStr = node.TypeStr.ToLower();
+
+                if (node is AeroFieldNode { IsEnum: true } fieldNode)
+                {
+                    typeStr = TypeAlias(fieldNode.EnumStr).ToLower();
+                }
+
+                byte byteType = typeStr switch
+                {
+                    "uint"                               => 0,
+                    "float"                              => 1,
+                    string t when t.EndsWith("entityid") => 2,
+                    "ulong"                              => 3,
+                    "byte"                               => 4,
+                    // there's no type 5
+                    "ushort"                             => 6,
+                    string t when t.EndsWith("timer")    => 7,
+                    "bool"                               => 8,
+
+                    "uint[]"                               => 128,
+                    "float[]"                              => 129,
+                    string t when t.EndsWith("entityid[]") => 130,
+                    "ulong[]"                              => 131,
+                    "byte[]"                               => 132,
+                    // there's no type 133 either
+                    "ushort[]"                             => 134,
+                    string t when t.EndsWith("timer[]")    => 135,
+                    "bool[]"                               => 136,
+
+                    _                                      => 255,
+                };
+
+                if (byteType == 255)
+                {
+                    Context.ReportDiagnostic(
+                        Diagnostic.Create(AeroGenerator.InvalidTypeInEncounterView, cd.GetLocation(), name, typeStr)
+                    );
+                }
+
+                var hexIdx = BitConverter.ToString(new[]{ fieldIdx });
+                var hexType = BitConverter.ToString(new[]{ byteType });
+                var hexCount = BitConverter.ToString(new[]{ count });
+
+                AddLine(
+                    $"0x{hexIdx}, 0x{hexType}, 0x{hexCount}, // idx: {fieldIdx}, type: {typeStr}, count: {count}, name: {name}");
+                AddLine(NameToHex(name));
+
+                fieldIdx++;
+            });
+
+            UnIndent();
+            AddLine("};"); // end static Header
+
+            using (Function("public byte[] GetHeader()"))
+            {
+                AddLine("return Header;");
+            }
+
+            AddLine();
+        }
+    }
+}

--- a/Aero/Aero.Gen/IAeroEncounterInterface.cs
+++ b/Aero/Aero.Gen/IAeroEncounterInterface.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Aero.Gen
+{
+    public interface IAeroEncounter
+    {
+        // Gets static encounter header created from indexes, types, element count
+        // and names for each encounter view field
+        public byte[] GetHeader();
+
+        // Get read logs, has the field name, offset and length
+        // should only have data in debug builds
+        public List<AeroReadLog> GetDiagReadLogs();
+
+        // Clear the read log list
+        public void ClearReadLogs();
+
+        // Unpacks a view update to this class, returns how many bytes were read
+        public int UnpackChanges(ReadOnlySpan<byte> data);
+
+        // Gets the number of bytes needed to pack all the changes.
+        public int GetPackedChangesSize();
+
+        // Packs what has changed into the buffer and returns the number of bytes written
+        // ClearViewChanges should be called after you pack the if clearDirtyAfterSend wasn't set, this reset the change field tracking
+        public int PackChanges(Span<byte> buffer, bool clearDirtyAfterSend = true);
+
+        // Will clear the internal data tracking if a field has been changed
+        public void ClearViewChanges();
+    }
+}

--- a/Aero/Aero.Gen/Properties/launchSettings.json
+++ b/Aero/Aero.Gen/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Generators": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "../Aero.UnitTests/Aero.UnitTests.csproj"
+    }
+  }
+}

--- a/Aero/Aero.UnitTests/EncounterTests.cs
+++ b/Aero/Aero.UnitTests/EncounterTests.cs
@@ -1,0 +1,331 @@
+﻿using System;
+using System.Linq;
+using Aero.Gen;
+using Aero.Gen.Attributes;
+using NUnit.Framework;
+
+namespace Aero.UnitTests
+{
+    [Aero(AeroGenTypes.View)]
+    [AeroEncounter("arc")]
+    public partial class ArcView
+    {
+        private uint arc_name;
+
+        private uint activity_string;
+
+        private ushort activity_visible;
+
+        [AeroNullable]
+        private EntityId healthbar_1;
+
+        private ushort healthbar_1_visible;
+    }
+
+    [Aero(AeroGenTypes.View)]
+    [AeroEncounter("AirTrafficControl")]
+    public partial class AirTrafficControlView
+    {
+        // has no fields
+    }
+
+    [Aero(AeroGenTypes.View)]
+    [AeroEncounter("MoreTypes")]
+    public partial class MoreTypesView
+    {
+        private uint name;
+
+        [AeroArray(2)]
+        private uint[] localizedTexts;
+
+        private ulong eta;
+
+        [AeroNullable]
+        private EntityId healthbar_1;
+
+        [AeroArray(3)]
+        private bool[] booleans;
+    }
+
+    [Aero(AeroGenTypes.View)]
+    [AeroEncounter("default")]
+    public partial class HudTimerView
+    {
+        private Timer hudtimer_timer;
+
+        private uint hudtimer_label;
+    }
+
+    [AeroBlock]
+    public struct EntityId
+    {
+        public ulong Backing;
+    }
+
+    [Flags]
+    public enum TimerState : byte
+    {
+        CountingDown = 1,
+        Paused = 2,
+    }
+
+    [AeroBlock]
+    public struct Timer
+    {
+        public TimerState State;
+
+        [AeroIf(nameof(State), AeroIfAttribute.Ops.DoesntHaveFlag, TimerState.Paused)]
+        public ulong Micro;
+
+        [AeroIf(nameof(State), AeroIfAttribute.Ops.HasFlag, TimerState.Paused)]
+        public float Seconds;
+    }
+
+    public class EncounterTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public void ArcHeaderTest()
+        {
+            var arc = new ArcView();
+
+            var expectedHeader = new byte[]
+            {
+                0x61, 0x72, 0x63, 0x00,
+                0x00, 0x00, 0x01,
+                0x61, 0x72, 0x63, 0x5F, 0x6E, 0x61, 0x6D, 0x65, 0x00,
+                0x01, 0x00, 0x01,
+                0x61, 0x63, 0x74, 0x69, 0x76, 0x69, 0x74, 0x79, 0x5F, 0x73, 0x74, 0x72, 0x69, 0x6E, 0x67, 0x00,
+                0x02, 0x06, 0x01,
+                0x61, 0x63, 0x74, 0x69, 0x76, 0x69, 0x74, 0x79, 0x5F, 0x76, 0x69, 0x73, 0x69, 0x62, 0x6C, 0x65, 0x00,
+                0x03, 0x02, 0x01,
+                0x68, 0x65, 0x61, 0x6C, 0x74, 0x68, 0x62, 0x61, 0x72, 0x5F, 0x31, 0x00,
+                0x04, 0x06, 0x01,
+                0x68, 0x65, 0x61, 0x6C, 0x74, 0x68, 0x62, 0x61, 0x72, 0x5F, 0x31, 0x5F, 0x76, 0x69, 0x73, 0x69, 0x62, 0x6C, 0x65, 0x00,
+            };
+
+            if (expectedHeader.SequenceEqual(arc.GetHeader()))
+            {
+                Assert.Pass();
+            }
+
+            Assert.Fail();
+        }
+
+        [Test]
+        public void AirTrafficControlHeaderTest()
+        {
+            var atc = new AirTrafficControlView();
+
+            var expectedHeader = new byte[]
+            {
+                0x41, 0x69, 0x72, 0x54, 0x72, 0x61, 0x66, 0x66, 0x69, 0x63, 0x43, 0x6F, 0x6E, 0x74, 0x72, 0x6F, 0x6C, 0x00,
+            };
+
+            if (expectedHeader.SequenceEqual(atc.GetHeader()))
+            {
+                Assert.Pass();
+            }
+
+            Assert.Fail();
+        }
+
+        [Test]
+        public void HudTimerPackChangesTest()
+        {
+            var hudTimer = new HudTimerView
+            {
+                hudtimer_timerProp = new Timer() {State = TimerState.Paused, Seconds = 15},
+                hudtimer_labelProp = 10082,
+            };
+
+            var bytes = new byte[]
+            {
+                0x00,
+                0x02, 0x00, 0x00, 0x70, 0x41,
+                0x01,
+                0x62, 0x27, 0x00, 0x00
+            };
+            var packedBuffer = new byte[bytes.Length];
+            var lenPacked = hudTimer.PackChanges(packedBuffer);
+
+            if (lenPacked == packedBuffer.Length && bytes.SequenceEqual(packedBuffer)) {
+                Assert.Pass();
+            }
+
+            Assert.Fail();
+        }
+
+        [Test]
+        public void MoreTypesPackChangesTest()
+        {
+            var encounter = new MoreTypesView
+            {
+                nameProp = 10093,
+                booleansProp = new bool[] { true, false, true },
+            };
+
+            var bytes = new byte[]
+            {
+                0x00,
+                0x6D, 0x27, 0x00, 0x00,
+
+                0x04, 0x00,
+                0x01,
+                0x04, 0x01,
+                0x00,
+                0x04, 0x02,
+                0x01,
+            };
+            var packedBuffer = new byte[bytes.Length];
+            var lenPacked = encounter.PackChanges(packedBuffer);
+
+            if (lenPacked == packedBuffer.Length && bytes.SequenceEqual(packedBuffer)) {
+                Assert.Pass();
+            }
+
+            Assert.Fail();
+        }
+
+        [Test]
+        public void MoreTypesPackChangesWithNullableNullTest()
+        {
+            var encounter = new MoreTypesView
+            {
+                nameProp = 10329,
+                healthbar_1Prop = null,
+            };
+
+            var bytes = new byte[]
+            {
+                0x00,
+                0x59, 0x28, 0x00, 0x00,
+
+                0x83,
+            };
+            var packedBuffer = new byte[bytes.Length];
+            var lenPacked = encounter.PackChanges(packedBuffer);
+
+            if (lenPacked == packedBuffer.Length && bytes.SequenceEqual(packedBuffer)) {
+                Assert.Pass();
+            }
+
+            Assert.Fail();
+        }
+
+        [Test]
+        public void HudTimerUnpackChangesTest()
+        {
+            var hudTimer = new HudTimerView
+            {
+                hudtimer_timerProp = new Timer() {State = TimerState.Paused, Seconds = 15},
+                hudtimer_labelProp = 10329,
+            };
+
+            var bytes = new byte[]
+            {
+                0x00,
+                0x01, 0x40, 0x79, 0x39, 0xB3, 0x81, 0x18, 0x06, 0x00,
+                0x01,
+                0x62, 0x27, 0x00, 0x00
+            };
+            var lenUnpacked = hudTimer.UnpackChanges(bytes);
+
+            if (lenUnpacked == bytes.Length
+                && hudTimer.hudtimer_labelProp == 10082
+                && hudTimer.hudtimer_timerProp.State == TimerState.CountingDown
+                && hudTimer.hudtimer_timerProp.Micro == 1715795197000000) {
+                Assert.Pass();
+            }
+
+            Assert.Fail();
+        }
+
+        [Test]
+        public void MoreTypesUnpackChangesTest()
+        {
+            var encounter = new MoreTypesView
+            {
+                nameProp = 10082,
+                booleansProp = new bool[] { true, false, true },
+            };
+
+            var bytes = new byte[]
+            {
+                0x00,
+                0x6D, 0x27, 0x00, 0x00,
+
+                0x04, 0x00,
+                0x00,
+                0x04, 0x01,
+                0x01,
+                0x04, 0x02,
+                0x00,
+            };
+            var lenUnpacked = encounter.UnpackChanges(bytes);
+
+            if (lenUnpacked == bytes.Length
+                && encounter.nameProp == 10093
+                && encounter.booleansProp.SequenceEqual(new bool[] { false, true, false })
+                ) {
+                Assert.Pass();
+            }
+
+            Assert.Fail();
+        }
+
+        [Test]
+        public void MoreTypesUnpackChangesWithNullableNullTest()
+        {
+            var encounter = new MoreTypesView
+            {
+                localizedTextsProp = new uint[] { 10342, 10343 },
+                healthbar_1Prop = new EntityId() { Backing = 2305005520655996928 },
+            };
+
+            var bytes = new byte[]
+            {
+                0x01, 0x00,
+                0x69, 0x28, 0x00, 0x00,
+                0x01, 0x01,
+                0x6A, 0x28, 0x00, 0x00,
+
+                0x83,
+            };
+            var lenUnpacked = encounter.UnpackChanges(bytes);
+
+            if (lenUnpacked == bytes.Length
+                && encounter.localizedTextsProp.SequenceEqual(new uint[] { 10345, 10346})
+                && encounter.healthbar_1Prop == null) {
+                Assert.Pass();
+            }
+
+            Assert.Fail();
+        }
+
+        [Test]
+        public void MoreTypesGetPackedChangesSizeTest()
+        {
+            var encounter = new MoreTypesView
+            {
+                nameProp = 10093,
+                localizedTextsProp = new uint[] { 10142, 10227 },
+                etaProp = 1715795197000000,
+                healthbar_1Prop = new EntityId() { Backing = 2305005520655996928 },
+                booleansProp = new bool[] { false, false, true },
+            };
+
+            var lenPacked = encounter.GetPackedChangesSize();
+
+            if (lenPacked == 44) {
+                Assert.Pass();
+            }
+
+            Assert.Fail();
+        }
+    }
+}


### PR DESCRIPTION
Messages `EncounterUIScopeIn` and `EncounterUIUpdate` contain data in format similar to the one seen in view update messages (msg id 1), [described in the wiki](https://github.com/themeldingwars/Documentation/wiki/Views%2C-Updates-and-Keyframes#update-msg-id-1).
I grouped and added comments to bytes of few types of ScopeIn messages found in replay files [in this gist file](https://gist.github.com/SzymonKaminski/024a74cfa234487b71d93fe25c2e0bb2).

At the beginning, there's encounter id.
Length of header in bytes and string telling encounter type is next.
Then, ScopeIn message contains header with info about fields: index, type (similar to [SincardFieldDataType](https://github.com/themeldingwars/AeroMessages/blob/6d91f4cb66d6af6728f201d26fc2248cf1abbc16/AeroMessages/GSS/V66/Shared.cs#L69)), element count, name for each field.
Afterwards there's schema version that has to be equal to 2 in last version of client.
At the end there are values of previously mentioned fields, in both ScopeIn and Update messages. 
Values of array fields are prefixed with indexes of both the field and the element within the array, so they take two bytes and not just one.

PR reuses methods created to work with views, and add bits specific to encounters, to simplify creating new types of encounters and working with their instances, so that they could be treated as views nested in EncounterUI messages.
Static class AeroEncounters is also added to be used by PacketPeep.
